### PR TITLE
Update for GHC 7.10

### DIFF
--- a/Data/Time/RFC2822.hs
+++ b/Data/Time/RFC2822.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE CPP, TypeSynonymInstances, FlexibleInstances #-}
 -- |                                                                               
 -- Module      : Data.Time.RFC2822
 -- Copyright   : (c) 2011 Hugo Daniel Gomes
@@ -36,11 +36,14 @@ module Data.Time.RFC2822 (
     RFC2822(showRFC2822, readRFC2822)
 ) where
 
+#if __GLASGOW_HASKELL__ < 710
+import System.Locale
+#endif
+
 import Data.Time.Format
 import Data.Time.LocalTime
 import Data.Time.Calendar
 import Data.Maybe 
-import System.Locale
 import qualified Data.Attoparsec.Text as A
 import Data.Attoparsec.Text
 import qualified Data.Attoparsec.Combinator as AC

--- a/Data/Time/RFC3339.hs
+++ b/Data/Time/RFC3339.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE CPP, TypeSynonymInstances, FlexibleInstances #-}
 -- |                                                                               
 -- Module      : Data.Time.RFC3339
 -- Copyright   : (c) 2011 Hugo Daniel Gomes
@@ -33,11 +33,14 @@ module Data.Time.RFC3339 (
     RFC3339(showRFC3339, readRFC3339)
 ) where
 
+#if __GLASGOW_HASKELL__ < 710
+import System.Locale
+#endif
+
 import Data.Time.Format
 import Data.Time.LocalTime
 import Data.Time.Calendar
 import Data.Maybe 
-import System.Locale
 
 test1 = "1985-04-12T23:20:50.52Z"
 test2 = "1996-12-19T16:39:57-08:00"

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -30,6 +30,7 @@ library
   build-depends:
     base < 5, 
     time >= 1.2, 
+    attoparsec,
     old-locale
 
   exposed-modules:


### PR DESCRIPTION
- Add attoparsec to build-depends
- Conditionally import System.Locale

I'm not sure if this is the correct fix, but it got things working again on my system.