### PR TITLE
Use TextualMonoid to allow String, lazy Text and strict Text.

### DIFF
--- a/Data/Time/RFC3339.hs
+++ b/Data/Time/RFC3339.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 -- |
 -- Module      : Data.Time.RFC3339
@@ -9,15 +10,15 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
--- Support for reading and displaying time in the format specified by 
+-- Support for reading and displaying time in the format specified by
 -- the RFC3339 <http://www.ietf.org/rfc/rfc3339.txt>
 --
 -- Example of usage:
--- >
+--
 -- > import Data.Time.LocalTime
 -- >
--- > showTime :: IO String
--- > showTime = getZonedTime >>= return . showRFC3339
+-- > showTime :: IO Text
+-- > showTime = formatTimeRFC3339 <$> getZonedTime
 -- >
 -- > example1 = "1985-04-12T23:20:50.52Z"
 -- > example2 = "1996-12-19T16:39:57-08:00"
@@ -26,62 +27,53 @@
 -- > example5 = "1937-01-01T12:00:27.87+00:20"
 -- > examples = [example1,example2,example3,example4,example5]
 -- >
--- > readAll = map readRFC3339 examples
+-- > readAll = map parseTimeRFC3339 examples
 
 module Data.Time.RFC3339 (
     -- * Basic type class
     -- $basic
-    RFC3339(showRFC3339, readRFC3339)
+    formatTimeRFC3339, parseTimeRFC3339
 ) where
 
+import           Control.Applicative
 
-import Data.Time.Format
-import Data.Time.Locale.Compat
-import Data.Time.LocalTime
-import Data.Time.Calendar
-import Data.Maybe 
+import           Data.Maybe
+import           Data.Monoid             ((<>))
+import           Data.Monoid.Textual     hiding (foldr, map)
+import           Data.String             (fromString)
+import           Data.Text               (Text)
+import           Data.Time.Calendar
+import           Data.Time.Format
+import           Data.Time.Locale.Compat
+import           Data.Time.LocalTime
+import           Data.Time.Util
+
 
 test1 = "1985-04-12T23:20:50.52Z"
 test2 = "1996-12-19T16:39:57-08:00"
 test3 = "1990-12-31T23:59:60Z"
 test4 = "1990-12-31T15:59:60-08:00"
 test5 = "1937-01-01T12:00:27.87+00:20"
-tests :: [String]
+tests :: [Text]
 tests = [test1, test2, test3, test4, test5]
-testParse = length (catMaybes (map readRFC3339 tests)) == length tests
+testParse = length (catMaybes (map parseTimeRFC3339 tests)) == length tests
 
--- ----------------------------------------------------------------------------
--- The RFC3339 class definition
 
--- | This class is here to allow future support for other data types 
--- like Data.Text or Data.ByteString if that becomes necessary
-class RFC3339 a where
-  showRFC3339 :: ZonedTime -> a
-  readRFC3339 :: a -> Maybe ZonedTime
-  formatRFC3339 :: [a]
-
--- | For now there is only an instance for the String data type
-instance RFC3339 String where
-  showRFC3339 zt@(ZonedTime lt z) = 
-    formatTime defaultTimeLocale "%FT%T" zt ++ printZone
-    where
-      timeZoneStr = timeZoneOffsetString z
-      printZone = if timeZoneStr == timeZoneOffsetString utc
+formatTimeRFC3339 :: (TextualMonoid t) => ZonedTime -> t
+formatTimeRFC3339 zt@(ZonedTime lt z) = fromString (formatTime defaultTimeLocale "%FT%T" zt) <> fromString printZone
+  where timeZoneStr = timeZoneOffsetString z
+        printZone = if timeZoneStr == timeZoneOffsetString utc
                     then "Z"
-                    else take 3 timeZoneStr ++ ":" ++ drop 3 timeZoneStr
-  formatRFC3339 = [ "%FT%TZ"
-                  , "%FT%T%z"
-                  , "%FT%T%Q%z"
-                  , "%FT%T%QZ"
-                  ]
-  readRFC3339 t = foldr (tryP t) Nothing $ map p formatRFC3339
-    where 
-      p :: String -> String -> Maybe ZonedTime
-      p f s = parseTime defaultTimeLocale f s
+                    else take 3 timeZoneStr <> ":" <> drop 3 timeZoneStr
 
-      tryP :: String -> (String -> Maybe a) -> Maybe a -> Maybe a
-      tryP s f acc | isJust acc = acc
-                   | otherwise = f s
+formatsRFC3339 :: [Text]
+formatsRFC3339 = [ "%FT%TZ"
+                 , "%FT%T%z"
+                 , "%FT%T%Q%z"
+                 , "%FT%T%QZ"
+                 ]
 
-showTime :: IO String
-showTime = getZonedTime >>= return . showRFC3339
+parseTimeRFC3339 :: (TextualMonoid t) => t -> Maybe ZonedTime
+parseTimeRFC3339 t = foldr (<|>) Nothing $ map parse formatsRFC3339
+    where parse :: (TextualMonoid t) => t -> Maybe ZonedTime
+          parse format = parseTime defaultTimeLocale (toString format) (toString t)

--- a/Data/Time/Util.hs
+++ b/Data/Time/Util.hs
@@ -1,0 +1,9 @@
+module Data.Time.Util where
+
+import           Data.Function
+import           Data.Monoid.Textual
+
+toString :: (TextualMonoid t) => t -> String
+toString = flip fix mempty $ \recurse output input -> case splitCharacterPrefix input of
+  Just (char, suffix) -> recurse (output ++ [char]) suffix
+  _ -> output

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -2,14 +2,14 @@ Name:          timerep
 Version:       1.0.3
 Category:      Web, Time
 Synopsis:      Parse and display time according to some RFCs (RFC3339, RFC2822)
-Description:   
+Description:
     .
     Parse and display time according to some RFC's.
-    Supported: 
+    Supported:
     RFC3339 <http://www.ietf.org/rfc/rfc3339.txt>
     RFC2822 <http://www.ietf.org/rfc/rfc2822.txt>
     .
-    This package defines a type class to parse and read time representations 
+    This package defines a type class to parse and read time representations
     specified in some RFC's.
     Right now there is only support for reading and showing String
     .
@@ -22,13 +22,15 @@ Copyright:     Hugo Daniel Gomes
 Cabal-version: >= 1.6
 License:       BSD3
 License-file:  LICENSE
-source-repository head                                                             
-  type:     git                                                                    
+source-repository head
+  type:     git
   location: git://github.com/HugoDaniel/RFC3339.git
 
 library
   build-depends:
     base < 5,
+    monoid-subclasses,
+    text,
     time >= 1.2,
     time-locale-compat,
     attoparsec
@@ -36,5 +38,8 @@ library
   exposed-modules:
     Data.Time.RFC3339
     Data.Time.RFC2822
+
+  other-modules:
+    Data.Time.Util
 
   extensions: TypeSynonymInstances FlexibleInstances


### PR DESCRIPTION
Also renamed functions to comply with the format/parse API of `Data.Time`.

Tests included in the source run correctly.