### PR TITLE
Clean-up (dependencies, unit tests) + support for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+env:
+ - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=1.22 GHCVER=7.10.2
+
+# Note: the distinction between `before_install` and `install` is not important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER happy-1.19.4 alex-3.1.3
+ - export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build
+ - cabal test
+ - cabal check
+ - cabal sdist
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")

--- a/Data/Time/RFC2822.hs
+++ b/Data/Time/RFC2822.hs
@@ -53,23 +53,6 @@ import           Data.Time.Format
 import           Data.Time.LocalTime
 import           Data.Time.Util
 
-test1  = "Fri, 21 Nov 1997 09:55:06 -0600"
-test2  = "Tue, 15 Nov 1994 12:45:26 GMT"
-test3  = "Tue, 1 Jul 2003 10:52:37 +0200"
-test4  = "Thu, 13 Feb 1969 23:32:54 -0330"
-test5  = "Mon, 24 Nov 1997 14:22:01 -0800"
-test6  = "Thu,          13\n     Feb\n  1969\n        23:32\n     -0330"
-test7  = "Thu,          13\n     Feb\n  1969\n        23:32\n     -0330 (Newfoundland Time)" -- Fails
-test8  = "24 Nov 1997 14:22:01 -0800"
-test9  = "15 Nov 1994 12:45:26 GMT"
-test10 = "Mon,24 Nov 1997 14:22:01 -0800"
-test11 = "Thu,\t13\n     Feb\n  1969\n        23:32\n     -0330 (Newfoundland Time)"  -- Fails
-test12 = "Thu, 13 Feb 1969 23:32 -0330 (Newfoundland Time)"  -- Fails
-tests :: [Text]
-tests = [test1, test2, test3, test4, test5, test6, test7, test8, test9, test10
-        , test11, test12]
-testParse = length (catMaybes (map parseTimeRFC2822 tests)) == length tests
-
 
 formatTimeRFC2822 :: (TextualMonoid t) => ZonedTime -> t
 formatTimeRFC2822 zt@(ZonedTime lt z) = fromString (formatTime defaultTimeLocale "%a, %e %b %Y %T" zt) <> fromString printZone

--- a/Data/Time/RFC2822.hs
+++ b/Data/Time/RFC2822.hs
@@ -50,7 +50,6 @@ import           Data.String                (fromString)
 import           Data.Text                  (Text)
 import           Data.Time.Calendar
 import           Data.Time.Format
-import           Data.Time.Locale.Compat
 import           Data.Time.LocalTime
 import           Data.Time.Util
 

--- a/Data/Time/RFC3339.hs
+++ b/Data/Time/RFC3339.hs
@@ -48,16 +48,6 @@ import           Data.Time.LocalTime
 import           Data.Time.Util
 
 
-test1 = "1985-04-12T23:20:50.52Z"
-test2 = "1996-12-19T16:39:57-08:00"
-test3 = "1990-12-31T23:59:60Z"
-test4 = "1990-12-31T15:59:60-08:00"
-test5 = "1937-01-01T12:00:27.87+00:20"
-tests :: [Text]
-tests = [test1, test2, test3, test4, test5]
-testParse = length (catMaybes (map parseTimeRFC3339 tests)) == length tests
-
-
 formatTimeRFC3339 :: (TextualMonoid t) => ZonedTime -> t
 formatTimeRFC3339 zt@(ZonedTime lt z) = fromString (formatTime defaultTimeLocale "%FT%T" zt) <> fromString printZone
   where timeZoneStr = timeZoneOffsetString z

--- a/Data/Time/RFC3339.hs
+++ b/Data/Time/RFC3339.hs
@@ -38,13 +38,12 @@ module Data.Time.RFC3339 (
 import           Control.Applicative
 
 import           Data.Maybe
-import           Data.Monoid             ((<>))
-import           Data.Monoid.Textual     hiding (foldr, map)
-import           Data.String             (fromString)
-import           Data.Text               (Text)
+import           Data.Monoid         ((<>))
+import           Data.Monoid.Textual hiding (foldr, map)
+import           Data.String         (fromString)
+import           Data.Text           (Text)
 import           Data.Time.Calendar
 import           Data.Time.Format
-import           Data.Time.Locale.Compat
 import           Data.Time.LocalTime
 import           Data.Time.Util
 

--- a/Data/Time/RFC822.hs
+++ b/Data/Time/RFC822.hs
@@ -29,12 +29,11 @@ module Data.Time.RFC822 (
 import           Control.Applicative
 
 import           Data.Maybe
-import           Data.Monoid.Textual     hiding (foldr, map)
-import           Data.String             (fromString)
-import           Data.Text               (Text)
+import           Data.Monoid.Textual hiding (foldr, map)
+import           Data.String         (fromString)
+import           Data.Text           (Text)
 import           Data.Time.Calendar
 import           Data.Time.Format
-import           Data.Time.Locale.Compat
 import           Data.Time.LocalTime
 import           Data.Time.Util
 

--- a/Data/Time/RFC822.hs
+++ b/Data/Time/RFC822.hs
@@ -38,16 +38,6 @@ import           Data.Time.LocalTime
 import           Data.Time.Util
 
 
-test1 = "Wed, 02 Oct 2002 13:00:00 GMT"
-test2 = "Wed, 02 Oct 2002 13:00:00 +0100"
-test3 = "Wed, 02 Oct 2002 13:00 +0100"
-test4 = "02 Oct 2002 13:00 +0100"
-test5 = "02 Oct 02 13:00 +0100"
-tests :: [Text]
-tests = [test1, test2, test3, test4, test5]
-testParse = length (catMaybes (map parseTimeRFC822 tests)) == length tests
-
-
 formatTimeRFC822 :: (TextualMonoid t) => ZonedTime -> t
 formatTimeRFC822 zonedTime = fromString $ formatTime defaultTimeLocale "%a, %d %b %Y %X %z" zonedTime
 

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -41,8 +41,6 @@ library
   other-modules:
     Data.Time.Util
 
-  extensions: TypeSynonymInstances FlexibleInstances
-
 test-suite Tests
   type: exitcode-stdio-1.0
   hs-source-dirs: test

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -31,7 +31,6 @@ library
     monoid-subclasses,
     text,
     time >= 1.5,
-    time-locale-compat,
     attoparsec
 
   exposed-modules:
@@ -54,6 +53,5 @@ test-suite Tests
     cabal-test-quickcheck,
     QuickCheck,
     text,
-    time >= 1.2,
-    time-locale-compat,
+    time >= 1.5,
     timerep >= 1.0

--- a/timerep.cabal
+++ b/timerep.cabal
@@ -44,14 +44,15 @@ library
   extensions: TypeSynonymInstances FlexibleInstances
 
 test-suite Tests
-  type: detailed-0.9
+  type: exitcode-stdio-1.0
   hs-source-dirs: test
-  test-module: Test
+  main-is: Main.hs
   build-depends:
     base < 5,
-    Cabal >= 1.20.0,
-    cabal-test-quickcheck,
     QuickCheck,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
     text,
     time >= 1.5,
-    timerep >= 1.0
+    timerep >= 2


### PR DESCRIPTION
This PR addresses various issues (notably #10, #11):
- as you set the lower bound on `time` to 1.5 in 980a36611d81426f19b4b7248e63ec46cd87b329, there is no point in using `time-locale-compat` anymore;
- moved the unit tests from the source files to the actual test suite;
- removed GHC extensions from the cabal file, as they are already listed at the top of source files (which is cleaner);
- added a `.travis.yml` file to enable continuous integration.
- added a `.gitignore` file.